### PR TITLE
Fix framebuffer pixel comparison

### DIFF
--- a/updateScreen.c
+++ b/updateScreen.c
@@ -21,7 +21,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 #define OUT_T CONCAT3E(uint,OUT,_t)
 #define FUNCTION CONCAT2E(update_screen_,OUT)
-#define COMPRECT 12
+#define COMPRECT 4
 #define MIN(a,b) (((a)<(b))?(a):(b))
 #define MAX(a,b) (((a)>(b))?(a):(b))
 
@@ -29,16 +29,20 @@ void FUNCTION(void) {
 	OUT_T* b = (OUT_T*)readBufferFB();
 	OUT_T* a = (OUT_T*)vncbuf;
 
+	struct fb_var_screeninfo scrinfo; //we'll need this to detect double FB on framebuffer
+	scrinfo = FB_getscrinfo();
+
 	idle = 1;
 
 	int i, j;
-	int offset = 0;
+	int offset = 0, fb_offset = 0;
 	int max_x = -1, max_y = -1, min_x = 99999, min_y = 99999;
 
 	for (j = 0; j < vncscr->height; j+=COMPRECT) {
 		offset = j * vncscr->width;
+		fb_offset = (j + scrinfo.yoffset) * scrinfo.xres_virtual + scrinfo.xoffset;
 		for (i = 0; i < vncscr->width; i+=COMPRECT) {
-			if (a[i + offset] != b[i + offset]) {
+			if (a[i + offset] != b[i + fb_offset]) {
 				min_y=MIN(j - COMPRECT, min_y);
 				max_y=MAX(j + COMPRECT, max_y);
 				idle = 0;
@@ -52,18 +56,12 @@ void FUNCTION(void) {
 		max_x=screenformat.width - 1;
 		max_y=MIN(screenformat.height - 1, max_y);
 
-		struct fb_var_screeninfo scrinfo; //we'll need this to detect double FB on framebuffer
-		scrinfo = FB_getscrinfo();
-
 		for (j = min_y; j <= max_y; j++) {
 			offset = j * vncscr->width;
-			for (i = 0; i < vncscr->width; i++) {
-				a[i + offset] = b[PIXEL_TO_VIRTUALPIXEL_FB(i, j)];
-			}
+			fb_offset = (j + scrinfo.yoffset) * scrinfo.xres_virtual + scrinfo.xoffset;
+			memcpy(vncbuf + offset, b + fb_offset, screenformat.width * screenformat.bitsPerPixel / CHAR_BIT);
 		}
 
-		offset = screenformat.width * min_y;
-		memcpy(vncbuf + offset, a + offset, screenformat.width * (max_y - min_y) * screenformat.bitsPerPixel / CHAR_BIT);
 		rfbMarkRectAsModified(vncscr, min_x, min_y, max_x, max_y);
 	}
 }


### PR DESCRIPTION
For non-native resolutions, it eliminates continuous unnecessary refresh cycles, thereby reducing performance issues.

_This has no effect on 1080p, there the performance problem is caused by another thing, but the solution for that is still in progress._